### PR TITLE
Potential fix for code scanning alert no. 109: Replacement of a substring with itself

### DIFF
--- a/generate-sitemap.js
+++ b/generate-sitemap.js
@@ -120,8 +120,10 @@ async function generateSitemap() {
       let urlPath = `/${file}`
         .replace(/\\/g, '/')
         .replace(/\/index\.(qmd|html)/, '/')
-        .replace(/\.(qmd|html)$/, '/')
-        .replace(/\/$/, '/'); // Ensure trailing slash
+        .replace(/\.(qmd|html)$/, '/');
+
+      // Ensure trailing slash
+      urlPath = urlPath.endsWith('/') ? urlPath : `${urlPath}/`;
 
       // Special handling for root index files
       if (urlPath === '/index/' || urlPath === '/') {


### PR DESCRIPTION
Potential fix for [https://github.com/brainworkup/brainworkup/security/code-scanning/109](https://github.com/brainworkup/brainworkup/security/code-scanning/109)

In general, the issue arises when `.replace()` is used with a regex that matches some substring, but the replacement string is identical to what was matched, leading to a no-op that usually hides a logic error. To fix it, we either (a) remove the useless replacement if it is genuinely unnecessary, or (b) change the pattern/replacement so that it performs the intended transformation (here: guaranteeing a trailing slash).

In this case, the surrounding code already normalizes paths:
- `/index.qmd` or `/index.html` becomes `/`
- Any remaining `.qmd` or `.html` extension is replaced by `/`, yielding a trailing slash.

What the code *appears* to want at line 124 is: “if the path does not end with a slash, append one; otherwise leave it unchanged.” That’s not what `.replace(/\/$/, '/')` does. A minimal change that preserves existing behavior for all current inputs but fulfills the comment is to replace the final `.replace(/\/$/, '/')` with a ternary that appends a slash only when missing:

```js
urlPath = urlPath.endsWith('/') ? urlPath : `${urlPath}/`;
```

This still “ensures” a trailing slash without disturbing previously-normalized values, and it removes the identity replacement CodeQL complains about. No new imports are needed. The edit is confined to `generate-sitemap.js`, line 124 within the `generateSitemap` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
